### PR TITLE
run & exec: raise SandboxCommandFailed if failure

### DIFF
--- a/generator/deploy_openshift_pod.py
+++ b/generator/deploy_openshift_pod.py
@@ -37,6 +37,7 @@ We came up with these solutions:
 """
 
 import datetime
+import json
 import logging
 import os
 import time
@@ -46,8 +47,9 @@ from kubernetes import config, client
 from kubernetes.client import V1DeleteOptions, V1Pod
 from kubernetes.client.rest import ApiException
 from kubernetes.stream import stream
+from kubernetes.stream.ws_client import ERROR_CHANNEL, WSClient
 
-from generator.exceptions import GeneratorDeployException
+from generator.exceptions import GeneratorDeployException, SandboxCommandFailed
 from generator.utils import run_command
 
 logger = logging.getLogger(__name__)
@@ -306,7 +308,7 @@ class OpenshiftDeployer(object):
                 )
 
         if resp.status.phase == "Failed":
-            raise RuntimeError("Pod failed, please check logs.")
+            raise SandboxCommandFailed(output=self.get_logs(), reason=str(resp.status))
 
         if self.mapped_dirs and command:
             raise RuntimeError(
@@ -325,7 +327,9 @@ class OpenshiftDeployer(object):
                         "The pod has failed execution: you should "
                         "inspect logs or check `oc describe`"
                     )
-                    break
+                    raise SandboxCommandFailed(
+                        output=self.get_logs(), reason=str(resp.status)
+                    )
                 if resp.status.phase == "Succeeded":
                     logger.info("All Containers in the pod have finished successfully.")
                     for m_dir in self.mapped_dirs:
@@ -364,16 +368,43 @@ class OpenshiftDeployer(object):
         for m_dir in self.mapped_dirs:
             self.copy_path_to_pod(m_dir)
         # FIXME: we're unable to get RC of the exec
-        response = stream(
+        ws_client: WSClient = stream(
             self.api.connect_get_namespaced_pod_exec,
             self.pod_name,
             self.k8s_namespace_name,
             # async_req=True,
             command=command,
+            stdin=False,
             stderr=True,
             stdout=True,
             tty=False,
+            _preload_content=False,  # <<< we need a client object
         )
+
+        # https://github.com/kubernetes-client/python/issues/812#issuecomment-499423823
+        ws_client.run_forever(timeout=60)
+        errors = ws_client.read_channel(ERROR_CHANNEL)
+        # read_all would consume ERR_CHANNEL, so read_all needs to be last
+        response = ws_client.read_all()
+        if errors:
+            # errors = '{"metadata":{},"status":"Success"}'
+            j = json.loads(errors)
+            status = j.get("status", None)
+            if status == "Success":
+                logger.info("exec command succeeded, yay!")
+            elif status == "Failure":
+                logger.info("exec command has failed")
+                # ('{"metadata":{},"status":"Failure","message":"command terminated with '
+                #  'non-zero exit code: Error executing in Docker Container: '
+                #  '1","reason":"NonZeroExitCode","details":{"causes":[{"reason":"ExitCode","message":"1"}]}}')
+                # e = json.loads(errors)
+                raise SandboxCommandFailed(output=response, reason=errors)
+            else:
+                logger.warning(
+                    "exec didn't yield the metadata we expect, mighty suspicous, %s",
+                    errors,
+                )
+
         logger.debug("exec response = %r" % response)
         for m_dir in self.mapped_dirs:
             self.copy_path_from_pod(m_dir)

--- a/generator/exceptions.py
+++ b/generator/exceptions.py
@@ -21,5 +21,17 @@
 # SOFTWARE.
 
 
-class GeneratorDeployException(Exception):
+class SandboxException(Exception):
+    """ There was an issue during execution. """
+
+
+class GeneratorDeployException(SandboxException):
     pass
+
+
+class SandboxCommandFailed(SandboxException):
+    """ The command executed in sandbox failed. """
+
+    def __init__(self, output: str, reason: str):
+        self.output: str = output
+        self.reason: str = reason

--- a/generator/exceptions.py
+++ b/generator/exceptions.py
@@ -32,6 +32,12 @@ class GeneratorDeployException(SandboxException):
 class SandboxCommandFailed(SandboxException):
     """ The command executed in sandbox failed. """
 
-    def __init__(self, output: str, reason: str):
+    def __init__(self, output: str, reason: str, rc: int):
+        """
+        :param output: output of the command
+        :param reason: reason the command failed
+        :param rc: return code
+        """
         self.output: str = output
         self.reason: str = reason
+        self.rc: int = rc

--- a/tests/e2e/test_ironman.py
+++ b/tests/e2e/test_ironman.py
@@ -47,8 +47,10 @@ def test_run_failure():
             ex.value.output
             == "ls: cannot access '/hauskrecht': No such file or directory\n"
         )
+        assert isinstance(ex.value, SandboxCommandFailed)
         assert "'exit_code': 2" in ex.value.reason
         assert "'reason': 'Error'" in ex.value.reason
+        assert ex.value.rc == 2
     finally:
         o.delete_pod()
 
@@ -63,9 +65,11 @@ def test_exec_failure():
             ex.value.output
             == "ls: cannot access '/hauskrecht': No such file or directory\n"
         )
+        assert isinstance(ex.value, SandboxCommandFailed)
         assert "2" in ex.value.reason
         assert "ExitCode" in ex.value.reason
         assert "NonZeroExitCode" in ex.value.reason
+        assert ex.value.rc == 2
     finally:
         o.delete_pod()
 


### PR DESCRIPTION
```
$ pytest-3 -vv tests/e2e/test_ironman.py
=== test session starts ===
platform linux -- Python 3.7.3, pytest-3.9.3, py-1.7.0, pluggy-0.8.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/tt/g/packit-service/generator, inifile:
plugins: cov-2.6.0
collected 8 items

tests/e2e/test_ironman.py::test_basic_e2e_inside PASSED                                   [ 12%]
tests/e2e/test_ironman.py::test_run_failure PASSED                                        [ 25%]
tests/e2e/test_ironman.py::test_exec_failure PASSED                                       [ 37%]
tests/e2e/test_ironman.py::test_local_path_e2e_inside_w_exec PASSED                       [ 50%]
tests/e2e/test_ironman.py::test_basic_e2e[test_basic_e2e_inside] PASSED                   [ 62%]
tests/e2e/test_ironman.py::test_basic_e2e[test_exec_failure] PASSED                       [ 75%]
tests/e2e/test_ironman.py::test_basic_e2e[test_run_failure] PASSED                        [ 87%]
tests/e2e/test_ironman.py::test_basic_e2e[test_local_path_e2e_inside_w_exec] PASSED       [100%]

=== 8 passed, 63 warnings in 38.73 seconds ===
```